### PR TITLE
Fix "Python path" not persisting from file picker

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -179,6 +179,8 @@ export default class LatexOCRSettingsTab extends PluginSettingTab {
                 .onClick(async () => {
                     const file = await picker("Open Python path", ["openFile"]) as string;
                     (pythonPath.components[1] as TextComponent).setValue(file)
+					this.plugin.settings.pythonPath = normalizePath(file);
+                    await this.plugin.saveSettings();
                 }))
             .addText(text => text
                 .setPlaceholder('path/to/python.exe')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -244,6 +244,8 @@ export default class LatexOCRSettingsTab extends PluginSettingTab {
                 .onClick(async () => {
                     const folder = await picker("Open cache directory", ["openDirectory"]) as string;
                     (cacheDir.components[1] as TextComponent).setValue(folder)
+					this.plugin.settings.cacheDirPath = normalizePath(folder)
+                    await this.plugin.saveSettings();
                 }))
             .addText(text => text
                 .setValue(this.plugin.settings.cacheDirPath)


### PR DESCRIPTION
Fix issue #31 by replicating the process for updating from the text box when updating from the file picker. It does not seem that updating the text with `setValue` triggered the callback.

(I can't find documentation on `normalizePath`, so this call may be unnecessary as the file picker already provides a valid path)