### PR TITLE
Reload model after unloading when starting the server

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -209,6 +209,7 @@ export default class LatexOCRSettingsTab extends PluginSettingTab {
                     new Notice("⚙️ Starting server...", 5000)
                     if (this.plugin.model) {
                         this.plugin.model.unload()
+                        this.plugin.model.load()
                     }
                 }))
 


### PR DESCRIPTION
The (re)start server button only unloaded the server before. We also want it to restart the server again to have it back up running.