### PR TITLE
Fix Exception calling application: "NoneType' object is not callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The status bar at the bottom will indicate the status of the server.
 | LatexOCR 🌐 | downloading model  |
 | LatexOCR ❌ | server unreachable |
 
+If the server is online but you encouter an error getting a response from the server, ensure that the Cache dir filepath is pointing to a valid folder and that the model has successfully been saved there. 
+
 ### GPU support
 
 You can check if GPU support is working by running:


### PR DESCRIPTION
closes: #22 

Add better debugging logs and a more descriptive health check to confirm if model is successfully loaded. Also mentioned it in the readme for people to self resolve.

In a perfect world, the default cache dir path would accurately autodetect the Obsidian vault location, but in the meanwhile this should make it much easier to diagnose and manually fix. 